### PR TITLE
Fix seal-secrets --only-changed to work with new secrets files

### DIFF
--- a/devops/tasks.py
+++ b/devops/tasks.py
@@ -391,7 +391,7 @@ def seal_secrets(env: str, only_changed=False) -> None:
         content = base64_encode_secrets(content)
         sealed_content = kube_seal(content, cert=secrets_pem)
 
-        if only_changed:
+        if only_changed and output_file.exists():
             master_key = get_master_key(env=env)
             sealed_original_content = output_file.read_text(encoding="utf-8")
             original_content = kube_unseal(

--- a/devops/tests/test_tasks.py
+++ b/devops/tests/test_tasks.py
@@ -280,6 +280,13 @@ def test_seal_unseal_secrets(clean_test_settings, decoded_secrets):
     resealed_content = TEST_ENV_SEALED_SECRETS_PATH.read_text(encoding="utf-8")
     assert original_sealed_content != resealed_content
 
+    # Check only_changed mode also works with newly added unsealed file that has
+    # no corresponding sealed file from before
+    TEST_ENV_SEALED_SECRETS_PATH.unlink()
+    assert TEST_ENV_UNSEALED_SECRETS_PATH.exists()
+    seal_secrets(TEST_ENV, only_changed=True)
+    assert TEST_ENV_SEALED_SECRETS_PATH.exists()
+
     TEST_ENV_SEALED_SECRETS_PATH.unlink()
     TEST_ENV_UNSEALED_SECRETS_PATH.unlink()
 


### PR DESCRIPTION
If you added a new `.unsealed-secrets.yaml` file, the `invoke seal-secrets --only-changed` crashed since it could not open the (non-existing) corresponding sealed version of the file. The right solution in this case is to create the new sealed version of the file and not update any of the other existing unmodified secrets.