### PR TITLE
Update kured to 1.4.5

### DIFF
--- a/kube/02-kured.yaml
+++ b/kube/02-kured.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   KURED_SLACK_URL: "https://hooks.slack.com/services/<...>"
   KURED_SLACK_NAME: "kured"
+  KURED_SLACK_CHANNEL: "alerting"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -16,7 +17,7 @@ rules:
   # Allow kubectl to drain/uncordon
   #
   # NB: These permissions are tightly coupled to the bundled version of kubectl; the ones below
-  # match https://github.com/kubernetes/kubernetes/blob/v1.12.1/pkg/kubectl/cmd/drain.go
+  # match https://github.com/kubernetes/kubernetes/blob/v1.17.7/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
   #
   - apiGroups: [""]
     resources: ["nodes"]
@@ -24,7 +25,7 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs:     ["list","delete","get"]
-  - apiGroups: ["extensions"]
+  - apiGroups: ["apps"]
     resources: ["daemonsets"]
     verbs:     ["get"]
   - apiGroups: [""]
@@ -51,7 +52,7 @@ metadata:
   name: kured
 rules:
   # Allow kured to lock/unlock itself
-  - apiGroups:     ["extensions"]
+  - apiGroups:     ["apps"]
     resources:     ["daemonsets"]
     resourceNames: ["kured"]
     verbs:         ["update"]
@@ -100,7 +101,9 @@ spec:
       restartPolicy: Always
       containers:
         - name: kured
-          image: docker.io/weaveworks/kured:1.2.0
+          image: docker.io/weaveworks/kured:1.4.5
+                 # If you find yourself here wondering why there is no
+                 # :latest tag on Docker Hub,see the FAQ in the README
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true # Give permission to nsenter /proc/1/ns/mnt
@@ -121,11 +124,17 @@ spec:
                 configMapKeyRef:
                   name: kured-config
                   key: KURED_SLACK_NAME
+            - name: KURED_SLACK_CHANNEL
+              valueFrom:
+                configMapKeyRef:
+                  name: kured-config
+                  key: KURED_SLACK_CHANNEL
           command:
             - /usr/bin/kured
           args:
             - "--slack-hook-url=$(KURED_SLACK_URL)"
             - "--slack-username=$(KURED_SLACK_NAME)"
+            - "--slack-channel=$(KURED_SLACK_CHANNEL)"
 
             #            - --alert-filter-regexp=^RebootRequired$
             #            - --blocking-pod-selector=runtime=long,cost=expensive
@@ -133,7 +142,11 @@ spec:
             #            - --blocking-pod-selector=...
             #            - --ds-name=kured
             #            - --ds-namespace=kube-system
+            #            - --end-time=23:59:59
             #            - --lock-annotation=weave.works/kured-node-lock
             #            - --period=1h
             #            - --prometheus-url=http://prometheus.monitoring.svc.cluster.local
+            #            - --reboot-days=sun,mon,tue,wed,thu,fri,sat
             #            - --reboot-sentinel=/var/run/reboot-required
+            #            - --start-time=0:00
+            #            - --time-zone=UTC


### PR DESCRIPTION
Update kured from 1.2.0 to 1.4.5.

Kured 1.4.x supports kubernetes versions 1.16.x, 1.17.x, 1.18.x.
Kured 1.2.0 supported kubernetes 1.12.x, 1.13.x, 1.14.x.

AKS retired kubernetes 1.14.x on 1 July 2020.