### PR TITLE
Update kured to 1.6.1

### DIFF
--- a/kube/02-kured.yaml
+++ b/kube/02-kured.yaml
@@ -17,7 +17,7 @@ rules:
   # Allow kubectl to drain/uncordon
   #
   # NB: These permissions are tightly coupled to the bundled version of kubectl; the ones below
-  # match https://github.com/kubernetes/kubernetes/blob/v1.17.7/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+  # match https://github.com/kubernetes/kubernetes/blob/v1.19.4/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
   #
   - apiGroups: [""]
     resources: ["nodes"]
@@ -101,7 +101,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: kured
-          image: docker.io/weaveworks/kured:1.4.5
+          image: docker.io/weaveworks/kured:1.6.1
                  # If you find yourself here wondering why there is no
                  # :latest tag on Docker Hub,see the FAQ in the README
           imagePullPolicy: IfNotPresent
@@ -148,5 +148,7 @@ spec:
             #            - --prometheus-url=http://prometheus.monitoring.svc.cluster.local
             #            - --reboot-days=sun,mon,tue,wed,thu,fri,sat
             #            - --reboot-sentinel=/var/run/reboot-required
+            #            - --message-template-drain=Draining node %s
+            #            - --message-template-drain=Rebooting node %s
             #            - --start-time=0:00
             #            - --time-zone=UTC


### PR DESCRIPTION
Update kured from 1.4.5 to 1.6.1.

Kured 1.6.x supports kubernetes versions 1.18.x, 1.19.x, 1.20.x
Kured 1.4.x supported kubernetes versions 1.16.x, 1.17.x, 1.18.x.

AKS retires kubernetes 1.17.x on 30 April 2021 and starting from 31 March 2021 new clusters can't be created with 1.17.x.